### PR TITLE
Update goreleaser action to support modern architectures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
       -
         name: Unshallow
         run: git fetch --prune --unshallow
@@ -28,21 +28,22 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
       -
         name: Import GPG key
         id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@v2.1.0
-        env:
+        uses: crazy-max/ghaction-import-gpg@v5
+        with:
           # These secrets will need to be configured for the repository:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2.7.0
+        uses: goreleaser/goreleaser-action@v4
         with:
+          distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           # GitHub sets this automatically

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,6 +29,8 @@ builds:
   ignore:
     - goos: darwin
       goarch: '386'
+    - goos: windows
+      goarch: arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip


### PR DESCRIPTION
This PR addresses #30

What was done:
 * `goreleaser` action was updated to the latest version to support as many modern architectures as possible
 * `ghaction-import-gpg` was updated by [superseded](https://github.com/hashicorp/ghaction-import-gpg) action since Hashicorp dropped support for their original one
 * updated Go version used to build distribution to `1.16`, since it is the minimum required version needed to be able to produce `darwin_arm64` builds.
 * excluded `windows_arm64` build from the list since go `1.16` do not support this target.

What was not done intentionally:
 * Go was not updated to the latest version to keep the scope of changes as small as possible
 * goreleaser config file was not updated for the same reason.

To verify and evaluate the result and ability to generate artifacts, you can refer to the[ release generated by these changes in my fork](https://github.com/mou/carvel-terraform-provider/releases/tag/v0.11.2).