### PR TITLE
Fix unix-specific logging path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+---
+name: Tests
+
+on:
+  pull_request:
+    types: ['opened', 'reopened', 'synchronize']
+
+jobs:
+  go-test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+      - name: Run tests
+        run: go test ./...

--- a/pkg/kapp/kapp.go
+++ b/pkg/kapp/kapp.go
@@ -80,7 +80,7 @@ func (t *Kapp) Diff() (string, string, error) {
 
 	if err == nil {
 		return "", stderrStr, fmt.Errorf("Executing kapp: Expected "+
-			"non-0 exit code (stderr: %s)", err, stderrStr)
+			"non-0 exit code (stderr: %s)", stderrStr)
 	}
 
 	if exitError, ok := err.(*goexec.ExitError); ok {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1,6 +1,9 @@
 package provider
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/vmware-tanzu/terraform-provider-carvel/pkg/kapp"
@@ -11,7 +14,7 @@ import (
 )
 
 func Provider() terraform.ResourceProvider {
-	logger := logger.MustNewFileRoot("/tmp/terraform-provider-carvel.log")
+	logger := logger.MustNewFileRoot(filepath.Join(os.TempDir(), "terraform-provider-carvel.log"))
 	yttLogger := logger.WithLabel("ytt")
 	kbldLogger := logger.WithLabel("kbld")
 


### PR DESCRIPTION
This PR provides several enhancements:
* Fix for #29 by replacing the hardcoded "/tmp" path with os.TempDir
* CI tests on several OSes
* Removal of redundant argument in Errorf call

Closes #29